### PR TITLE
Refactor: change component name from Barner to Banner

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import './App.css'
 import Header from './components/layout/Header.jsx'
-import Barner from './components/layout/Barner.jsx'
+import Banner from './components/layout/Banner.jsx'
 import Nav from './components/layout/Nav.jsx'
 
 function App() {
@@ -10,7 +10,7 @@ function App() {
     <>
     <Header/>
     <Nav/>
-    <Barner/>
+    <Banner/>
 
      
       

--- a/src/components/layout/Banner.jsx
+++ b/src/components/layout/Banner.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-function Barner() {
+function Banner() {
   return (
     <section className='py-10'>
         <p className=" pb-4 text-4xl font-extrabold text-yellow-600">
@@ -13,4 +13,4 @@ function Barner() {
   )
 }
 
-export default Barner
+export default Banner


### PR DESCRIPTION
I notice a typographical error in previous component name (Barner). Name changed to Banner for clear understanding.